### PR TITLE
Feat/self host delpoy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,11 +6,11 @@ env:
   DOCKER_IMAGE: balancing
   VERSION: '1.0'
   TARGET_FOLDER: images
-  HOST_NAME: 'https://balancing.britadtw.com'
+  HOST_NAME: 'https://balancing.britad.com'
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout latest code
         uses: actions/checkout@v3
@@ -23,34 +23,21 @@ jobs:
         id: build-docker
         run: docker build -t "${{env.DOCKER_IMAGE}}:${{env.VERSION}}.${{env.TAG_VERSION}}" --build-arg DATABASE_URL="${{secrets.DATABASE_URL}}" --build-arg HOST_NAME="${{env.HOST_NAME}}" .
 
-      - name: save docker image
-        id: save-docker
-        run: docker save -o "${{env.DOCKER_IMAGE}}.tar" "${{env.DOCKER_IMAGE}}:${{env.VERSION}}.${{env.TAG_VERSION}}"
-
-      - name: setup ssh
-        id: setup-ssh
+      - name: stop old container if exist
         run: |
-          echo "${{secrets.SSH_KEY}}" > key.pem
-          chmod 600 key.pem
+          docker stop "${{env.DOCKER_IMAGE}}" || true
+          docker rm "${{env.DOCKER_IMAGE}}" || true
 
-      - name: setup known hosts
-        id: setup-known-hosts
+      - name: deploy new container
         run: |
-          touch known_hosts
-          ssh-keyscan "${{secrets.SSH_HOST}}" >> known_hosts
-
-      - name: set folder
-        id: set-folder
-        run: echo "FOLDER="/${{env.TARGET_FOLDER}}/${{env.DOCKER_IMAGE}}"" >> $GITHUB_ENV
-
-      - name: create folder if not exist
-        id: create-folder
-        run: ssh -i key.pem -o UserKnownHostsFile=known_hosts "${{secrets.SSH_USER}}@${{secrets.SSH_HOST}}" "mkdir -p ${{env.FOLDER}} && docker stop ${{env.DOCKER_IMAGE}} || true"
-
-      - name: upload image
-        id: upload-image
-        run: scp -i key.pem -o UserKnownHostsFile=known_hosts -v "${{env.DOCKER_IMAGE}}.tar" "${{secrets.SSH_USER}}@${{secrets.SSH_HOST}}:${{env.FOLDER}}/${{env.DOCKER_IMAGE}}.tar"
-
-      - name: deploy
-        id: deploy
-        run: ssh -i key.pem -o UserKnownHostsFile=known_hosts "${{secrets.SSH_USER}}@${{secrets.SSH_HOST}}" "cd ${{env.FOLDER}} && docker load -i ${{env.DOCKER_IMAGE}}.tar && (docker rm ${{env.DOCKER_IMAGE}} || true) && docker run --rm -d --network main_network --name ${{env.DOCKER_IMAGE}} -p 3001:3000 -e DATABASE_URL="${{secrets.DATABASE_URL}}" -e HOST_NAME="${{env.HOST_NAME}}" -e CHANNEL_ID="${{secrets.CHANNEL_ID}}" -e CHANNEL_SECRET="${{secrets.CHANNEL_SECRET}}" ${{env.DOCKER_IMAGE}}:${{env.VERSION}}.${{env.TAG_VERSION}}"
+          docker run -d \
+            --name "${{env.DOCKER_IMAGE}}" \
+            --network main_network \
+            --restart=always \
+            -p 3001:3000 \
+            -e DATABASE_URL="${{secrets.DATABASE_URL}}" \
+            -e HOST_NAME="${{env.HOST_NAME}}" \
+            -e CHANNEL_ID="${{secrets.CHANNEL_ID}}" \
+            -e CHANNEL_SECRET="${{secrets.CHANNEL_SECRET}}" \
+            "${{env.DOCKER_IMAGE}}:${{env.VERSION}}.${{env.TAG_VERSION}}"
+        

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: build docker
         id: build-docker
-        run: docker build -t "${{env.DOCKER_IMAGE}}:${{env.VERSION}}.${{env.TAG_VERSION}}" --build-arg DATABASE_URL="${{secrets.DATABASE_URL}}" --build-arg HOST_NAME="${{env.HOST_NAME}}" .
+        run: docker build --network main_network -t "${{env.DOCKER_IMAGE}}:${{env.VERSION}}.${{env.TAG_VERSION}}" --build-arg DATABASE_URL="${{secrets.DATABASE_URL}}" --build-arg HOST_NAME="${{env.HOST_NAME}}" .
 
       - name: stop old container if exist
         run: |


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy.yml` to simplify and streamline the Docker build and deployment process. The changes remove SSH-based remote deployment steps and instead run Docker commands directly on a self-hosted runner, making the deployment faster and less complex.

**Workflow and deployment process simplification:**

* Changed `runs-on` from `ubuntu-latest` to `self-hosted`, indicating that the workflow now runs on a self-hosted runner instead of GitHub-hosted infrastructure.
* Removed all SSH-related steps, including key setup, known hosts configuration, remote folder creation, and image upload, eliminating the need for remote server access and file transfer.
* Added steps to stop and remove any existing Docker container before deploying the new one, ensuring a clean deployment.
* Updated Docker build and run commands to use the `main_network` Docker network and included necessary environment variables directly in the container run step.

**Configuration updates:**

* Changed `HOST_NAME` environment variable to use a new domain (`balancing.britad.com` instead of `balancing.britadtw.com`).