### PR TITLE
feat: update deployment configuration for self-hosted environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,11 +6,11 @@ env:
   DOCKER_IMAGE: balancing
   VERSION: '1.0'
   TARGET_FOLDER: images
-  HOST_NAME: 'https://balancing.britadtw.com'
+  HOST_NAME: 'https://balancing.britad.com'
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout latest code
         uses: actions/checkout@v3
@@ -21,36 +21,23 @@ jobs:
 
       - name: build docker
         id: build-docker
-        run: docker build -t "${{env.DOCKER_IMAGE}}:${{env.VERSION}}.${{env.TAG_VERSION}}" --build-arg DATABASE_URL="${{secrets.DATABASE_URL}}" --build-arg HOST_NAME="${{env.HOST_NAME}}" .
+        run: docker buildx build --network main_network -t "${{env.DOCKER_IMAGE}}:${{env.VERSION}}.${{env.TAG_VERSION}}" --build-arg DATABASE_URL="${{secrets.DATABASE_URL}}" --build-arg HOST_NAME="${{env.HOST_NAME}}" .
 
-      - name: save docker image
-        id: save-docker
-        run: docker save -o "${{env.DOCKER_IMAGE}}.tar" "${{env.DOCKER_IMAGE}}:${{env.VERSION}}.${{env.TAG_VERSION}}"
-
-      - name: setup ssh
-        id: setup-ssh
+      - name: stop old container if exist
         run: |
-          echo "${{secrets.SSH_KEY}}" > key.pem
-          chmod 600 key.pem
+          docker stop "${{env.DOCKER_IMAGE}}" || true
+          docker rm "${{env.DOCKER_IMAGE}}" || true
 
-      - name: setup known hosts
-        id: setup-known-hosts
+      - name: deploy new container
         run: |
-          touch known_hosts
-          ssh-keyscan "${{secrets.SSH_HOST}}" >> known_hosts
-
-      - name: set folder
-        id: set-folder
-        run: echo "FOLDER="/${{env.TARGET_FOLDER}}/${{env.DOCKER_IMAGE}}"" >> $GITHUB_ENV
-
-      - name: create folder if not exist
-        id: create-folder
-        run: ssh -i key.pem -o UserKnownHostsFile=known_hosts "${{secrets.SSH_USER}}@${{secrets.SSH_HOST}}" "mkdir -p ${{env.FOLDER}} && docker stop ${{env.DOCKER_IMAGE}} || true"
-
-      - name: upload image
-        id: upload-image
-        run: scp -i key.pem -o UserKnownHostsFile=known_hosts -v "${{env.DOCKER_IMAGE}}.tar" "${{secrets.SSH_USER}}@${{secrets.SSH_HOST}}:${{env.FOLDER}}/${{env.DOCKER_IMAGE}}.tar"
-
-      - name: deploy
-        id: deploy
-        run: ssh -i key.pem -o UserKnownHostsFile=known_hosts "${{secrets.SSH_USER}}@${{secrets.SSH_HOST}}" "cd ${{env.FOLDER}} && docker load -i ${{env.DOCKER_IMAGE}}.tar && (docker rm ${{env.DOCKER_IMAGE}} || true) && docker run --rm -d --network main_network --name ${{env.DOCKER_IMAGE}} -p 3001:3000 -e DATABASE_URL="${{secrets.DATABASE_URL}}" -e HOST_NAME="${{env.HOST_NAME}}" -e CHANNEL_ID="${{secrets.CHANNEL_ID}}" -e CHANNEL_SECRET="${{secrets.CHANNEL_SECRET}}" ${{env.DOCKER_IMAGE}}:${{env.VERSION}}.${{env.TAG_VERSION}}"
+          docker run -d \
+            --name "${{env.DOCKER_IMAGE}}" \
+            --network main_network \
+            --restart=always \
+            -p 3001:3000 \
+            -e DATABASE_URL="${{secrets.DATABASE_URL}}" \
+            -e HOST_NAME="${{env.HOST_NAME}}" \
+            -e CHANNEL_ID="${{secrets.CHANNEL_ID}}" \
+            -e CHANNEL_SECRET="${{secrets.CHANNEL_SECRET}}" \
+            "${{env.DOCKER_IMAGE}}:${{env.VERSION}}.${{env.TAG_VERSION}}"
+        


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy.yml` to simplify and streamline the Docker deployment process. The main changes include switching to a self-hosted runner, updating the host name, and replacing the previous SSH-based image transfer and deployment steps with direct Docker commands.

**Workflow and deployment process improvements:**

* Changed `runs-on` from `ubuntu-latest` to `self-hosted` to use a self-hosted GitHub Actions runner for the deployment job.
* Updated the `HOST_NAME` environment variable to use `https://balancing.britad.com` instead of the previous domain.

**Docker build and deployment simplification:**

* Replaced the standard `docker build` command with `docker buildx build` using the `main_network` for building the image.
* Removed all SSH-related steps, image saving, and SCP transfer; now the workflow stops and removes any existing container and runs the new container directly with the required environment variables and network settings.